### PR TITLE
Add admin moderation tools for posts and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Moderation
+
+To allow administrators to remove offensive content set a secret key in your environment:
+
+```bash
+export MODERATION_SECRET="choose-a-strong-secret"
+```
+
+Moderators can enter this key in the post page to activate a moderation session. While the session is active, they can delete any publication or comment directly from the interface.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/app/post/[slug]/post-editor.tsx
+++ b/src/app/post/[slug]/post-editor.tsx
@@ -15,12 +15,16 @@ export function PostOwnerPanel({
   content,
   alias,
   tags,
+  canEdit,
+  canModerate,
 }: {
   slug: string;
   title: string;
   content: string;
   alias: string;
   tags: string;
+  canEdit: boolean;
+  canModerate: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const router = useRouter();
@@ -28,10 +32,10 @@ export function PostOwnerPanel({
   const [deleteState, deleteAction] = useFormState(deletePost, initialDeleteState);
 
   useEffect(() => {
-    if (updateState?.message) {
+    if (canEdit && updateState?.message) {
       setEditing(false);
     }
-  }, [updateState?.message]);
+  }, [updateState?.message, canEdit]);
 
   useEffect(() => {
     if (deleteState?.message) {
@@ -39,26 +43,33 @@ export function PostOwnerPanel({
     }
   }, [deleteState?.message, router]);
 
+  if (!canModerate) {
+    return null;
+  }
+
   return (
 
     <div className="mt-6 rounded-3xl border border-indigo-300/30 bg-indigo-950/40 p-6 text-sm text-white/80 shadow-inner shadow-indigo-900/40">
 
       <div className="flex flex-wrap items-center justify-between gap-4">
         <p>
-          Esta publicación está vinculada a tu navegador. Aquí puedes editarla, añadir novedades o eliminarla cuando lo
-          necesites.
+          {canEdit
+            ? "Esta publicación está vinculada a tu navegador. Aquí puedes editarla, añadir novedades o eliminarla cuando lo necesites."
+            : "Has iniciado sesión como moderador/a. Si detectas contenido ofensivo o que incumple las normas puedes retirarlo desde aquí."}
         </p>
-        <button
-          type="button"
-          onClick={() => setEditing(prev => !prev)}
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={() => setEditing(prev => !prev)}
 
-          className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-indigo-100 transition hover:border-white/40 hover:bg-white/20"
+            className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-indigo-100 transition hover:border-white/40 hover:bg-white/20"
 
-        >
-          {editing ? "Cerrar edición" : "Editar publicación"}
-        </button>
+          >
+            {editing ? "Cerrar edición" : "Editar publicación"}
+          </button>
+        ) : null}
       </div>
-      {editing ? (
+      {editing && canEdit ? (
 
         <form action={updateAction} className="mt-6 space-y-5 text-white">
           <input type="hidden" name="slug" value={slug} />
@@ -155,8 +166,9 @@ export function PostOwnerPanel({
         ) : null}
         <DeleteButton />
         <p>
-          Si eliminas el mensaje desaparecerá de inmediato junto con todos los comentarios asociados. Esta acción no se puede
-          deshacer.
+          {canEdit
+            ? "Si eliminas el mensaje desaparecerá de inmediato junto con todos los comentarios asociados. Esta acción no se puede deshacer."
+            : "Eliminar la publicación la retirará de inmediato junto con todos los comentarios asociados. Esta acción no se puede deshacer."}
         </p>
       </form>
     </div>

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,25 @@
+import { createHash } from "crypto";
+
+export function isModerationEnabled(): boolean {
+  return Boolean(process.env.MODERATION_SECRET);
+}
+
+export function moderationSecretHash(): string | null {
+  const secret = process.env.MODERATION_SECRET;
+  if (!secret) {
+    return null;
+  }
+  return createHash("sha256").update(secret).digest("hex");
+}
+
+export function hashModerationSecret(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function isAdminTokenValid(token: string | undefined): boolean {
+  const expected = moderationSecretHash();
+  if (!token || !expected) {
+    return false;
+  }
+  return token === expected;
+}

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -13,3 +13,7 @@ export function postReactionCookie(slug: string) {
 export function commentReactionCookie(id: string) {
   return `comment-reactions-${id}`;
 }
+
+export function adminTokenCookie() {
+  return "va-admin-token";
+}


### PR DESCRIPTION
## Summary
- add admin authentication helpers and tokens so moderators can sign in with a secret
- extend post and comment server actions plus UI to allow admins to delete offensive content
- document the MODERATION_SECRET configuration needed to enable moderation tools

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db576b1e148323bfdc0454248aa253