### PR TITLE
Fix redirect after deleting post

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 
 import type { Prisma } from "@prisma/client";
@@ -393,9 +394,8 @@ export async function deletePost(
   cookieStore.delete(postTokenCookie(slug));
 
   revalidatePath("/");
-  revalidatePath(`/post/${slug}`);
 
-  return { message: "La publicación se eliminó." };
+  redirect("/");
 }
 
 export async function createComment(


### PR DESCRIPTION
## Summary
- redirect users to the home page after deleting a post to avoid landing on a 404 page
- revalidate the home page feed after removal so the deleted post disappears immediately

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db5be12648832395e39ec6fdb17bea