### PR TITLE
Skip Prisma migrations in hosted builds

### DIFF
--- a/scripts/with-migrations.ts
+++ b/scripts/with-migrations.ts
@@ -36,7 +36,22 @@ function runCommand(command: string, args: string[]) {
   });
 }
 
+function isTruthyEnv(value: string | undefined) {
+  if (!value) return false;
+  return ["1", "true", "yes"].includes(value.toLowerCase());
+}
+
 async function ensureMigrations() {
+  if (
+    isTruthyEnv(process.env.SKIP_PRISMA_MIGRATIONS) ||
+    isTruthyEnv(process.env.VERCEL)
+  ) {
+    console.warn(
+      "[with-migrations] Skipping Prisma migrations due to CI/hosting environment."
+    );
+    return;
+  }
+
   const databaseUrl = process.env.DATABASE_URL?.trim();
   const directUrl = process.env.DIRECT_URL?.trim();
 


### PR DESCRIPTION
## Summary
- add helper for checking truthy environment variables
- skip Prisma migrations when running in Vercel or when explicitly requested

## Testing
- not run (network-dependent build fails when fetching Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68db6270f7bc83238b9f20433efd7b1f